### PR TITLE
Vue.js: merge vue-scoped-slots with slot.

### DIFF
--- a/examples/vue.web-types.json
+++ b/examples/vue.web-types.json
@@ -85,14 +85,12 @@
             {
               "name": "cell({key})",
               "pattern": "cell\\([A-Za-z0-9_$]+\\)"
-            }
-          ],
-          "vue-scoped-slots": [
+            },
             {
               "name": "scoped-example",
               "description": "This slot allows you to access component's scope",
               "doc-url": "http://example.com/docs/components/ex-component#scoped-slot.scoped-example",
-              "properties": [
+              "vue-properties": [
                 {
                   "name": "color",
                   "type": [
@@ -118,7 +116,7 @@
                 "regex": "col-[a-z0-9]",
                 "case-sensitive": false
               },
-              "properties": [
+              "vue-properties": [
                 {
                   "name": "content",
                   "type": "string"

--- a/schema/web-types.json
+++ b/schema/web-types.json
@@ -100,10 +100,9 @@
           }
         },
         "vue-scoped-slots": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/html-tag-vue-scoped-slot"
-          }
+          "description": "Deprecated. Use regular 'slot' property instead and specify 'vue-properties' to provide slot scope information.",
+          "type": "null",
+          "additionalProperties": false
         },
         "vue-model": {
           "$ref": "#/definitions/html-tag-vue-model"
@@ -280,29 +279,8 @@
         },
         "doc-url": {
           "$ref": "#/definitions/doc-url"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false
-    },
-    "html-tag-vue-scoped-slot": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "$ref": "#/definitions/name"
         },
-        "pattern": {
-          "$ref": "#/definitions/pattern"
-        },
-        "description": {
-          "$ref": "#/definitions/description"
-        },
-        "doc-url": {
-          "$ref": "#/definitions/doc-url"
-        },
-        "properties": {
+        "vue-properties": {
           "description": "Specify properties of the slot scope",
           "type": "array",
           "items": {


### PR DESCRIPTION
The only difference between `vue-scoped-slots` and `slots` is the `properties` property. Let's get rid of `vue-scoped-slots` and add `vue-properties` property to `slots` objects. 

@tmorehouse @panstromek What do you think about the change? 