### PR TITLE
Fix: Pathbug which outputs wrong paths on generation

### DIFF
--- a/gen/vue-docgen-web-types/src/build.ts
+++ b/gen/vue-docgen-web-types/src/build.ts
@@ -134,7 +134,8 @@ async function writeDownWebTypesFile(config: WebTypesBuilderConfig, definitions:
 }
 
 function ensureRelative(path: string) {
-    return path.startsWith("./") || path.startsWith("../") ? path : "./" + path;
+    // The .replace() is a fix for paths that end up like "./src\\components\\General\\VerticalButton.vue" on windows machines.
+    return (path.startsWith("./") || path.startsWith("../") ? path : "./" + path).replace(/\\/g, '/');
 }
 
 async function extractInformation(


### PR DESCRIPTION
Fix: There is a bug during generation that will output paths like "./src\\components\\General\\VerticalButton.vue". I added a replace() which changes all "\\" to "/"": finished

[#23 ](https://github.com/JetBrains/web-types/issues/23)