### PR TITLE
fix: add missing minimist dependency

### DIFF
--- a/gen/vue-docgen-web-types/package.json
+++ b/gen/vue-docgen-web-types/package.json
@@ -17,8 +17,9 @@
     "chokidar": "^3.4.2",
     "globby": "^11.0.1",
     "lodash": "^4.17.20",
-    "vue-docgen-api": "^4.30.0",
-    "mkdirp": "^1.0.4"
+    "minimist": "^1.2.8",
+    "mkdirp": "^1.0.4",
+    "vue-docgen-api": "^4.30.0"
   },
   "keywords": [
     "web-types",

--- a/gen/vue-docgen-web-types/yarn.lock
+++ b/gen/vue-docgen-web-types/yarn.lock
@@ -658,6 +658,11 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"


### PR DESCRIPTION
Since the `vue-docgen-web-types` package does not specify `minimist` in its dependencies, running the vue-docgen-web-types fails if you don't have `minimist` installed from a different package.

![Bildschirm­foto 2023-08-14 um 10 45 33](https://github.com/JetBrains/web-types/assets/5724535/451b79f9-e083-4438-9a36-a10eb4640bde)
