### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -85,7 +85,7 @@ Currently, the following component documentation formats are supported:
 - JSDoc using [styleguidist](https://vue-styleguidist.github.io/docs/Documenting.html#code-comments) `vue-docgen-api`
   library - add [`vue-docgen-web-types`](https://www.npmjs.com/package/vue-docgen-web-types) package to your project 
   and run the `vue-docgen-web-types` command. You can launch it in a watch mode by passing `--watch` and 
-  you can pass a custom configuration file via `--config` parameter. 
+  you can pass a custom configuration file via `--configFile` parameter. 
   See [config.d.ts](https://github.com/JetBrains/web-types/blob/master/gen/vue-docgen-web-types/types/config.d.ts)
   for detailed information on supported configuration file options.
   


### PR DESCRIPTION
In [Generating Web-Types](https://github.com/JetBrains/web-types?tab=readme-ov-file#generating-web-types), it's now `--configFile`
See https://www.npmjs.com/package/vue-docgen-web-types

![3328d9cad0439fef44190b4e14434eb4](https://github.com/JetBrains/web-types/assets/52148490/0a6b1749-c127-4919-be68-9a81e00e9b66)
