### PR TITLE
typo: update css contributions description typo

### DIFF
--- a/schema/web-types.json
+++ b/schema/web-types.json
@@ -1077,7 +1077,7 @@
     },
     "css": {
       "type": "object",
-      "description": "Contains contributions to CSS namespace. It's property names represent symbol kinds, its property values contain list of contributions of particular kind. There are6 predefined kinds, which integrate directly with IDE - properties, classes, functions, pseudo-elements, pseudo-classes and parts.",
+      "description": "Contains contributions to CSS namespace. It's property names represent symbol kinds, its property values contain list of contributions of particular kind. There are predefined kinds, which integrate directly with IDE - properties, classes, functions, pseudo-elements, pseudo-classes and parts.",
       "allOf": [
         {
           "$ref": "#/definitions/css-contributions-host"


### PR DESCRIPTION
Found a small typo in the CSS contributions while working on web-types for StencilJS. With this commit, we replace 'are6' with 'are'.

Let me know if you need anything from me here!